### PR TITLE
Fix links_node in struct_node

### DIFF
--- a/lib/yasuri/yasuri_links_node.rb
+++ b/lib/yasuri/yasuri_links_node.rb
@@ -6,10 +6,10 @@ require_relative 'yasuri_node'
 module Yasuri
   class LinksNode
     include Node
-    def inject(agent, page, opt = {})
+    def inject(agent, page, opt = {}, element = page)
       retry_count = opt[:retry_count] || 5
 
-      links = page.search(@xpath) || [] # links expected
+      links = element.search(@xpath) || [] # links expected
       links.map do |link|
         link_button = Mechanize::Page::Link.new(link, agent, page)
         child_page = Yasuri.with_retry(retry_count) { link_button.click }

--- a/lib/yasuri/yasuri_node.rb
+++ b/lib/yasuri/yasuri_node.rb
@@ -11,7 +11,7 @@ module Yasuri
       @xpath, @name, @children = xpath, name, children
     end
 
-    def inject(agent, page, opt = {})
+    def inject(agent, page, opt = {}, element = page)
       fail "#{Kernel.__method__} is not implemented."
     end
     def opts

--- a/lib/yasuri/yasuri_paginate_node.rb
+++ b/lib/yasuri/yasuri_paginate_node.rb
@@ -12,7 +12,7 @@ module Yasuri
       @limit = limit
     end
 
-    def inject(agent, page, opt = {})
+    def inject(agent, page, opt = {}, element = page)
       retry_count = opt[:retry_count] || 5
 
       child_results = []

--- a/lib/yasuri/yasuri_struct_node.rb
+++ b/lib/yasuri/yasuri_struct_node.rb
@@ -6,12 +6,12 @@ require_relative 'yasuri_node'
 module Yasuri
   class StructNode
     include Node
-    def inject(agent, page, opt = {})
-      sub_tags = page.search(@xpath)
+    def inject(agent, page, opt = {}, element = page)
+      sub_tags = element.search(@xpath)
       tree = sub_tags.map do |sub_tag|
         child_results_kv = @children.map do |child_node|
           child_name = Yasuri.NodeName(child_node.name, opt)
-          [child_name, child_node.inject(agent, sub_tag, opt)]
+          [child_name, child_node.inject(agent, page, opt, sub_tag)]
         end
         Hash[child_results_kv]
       end

--- a/lib/yasuri/yasuri_text_node.rb
+++ b/lib/yasuri/yasuri_text_node.rb
@@ -18,8 +18,8 @@ module Yasuri
 
     end
 
-    def inject(agent, page, opt = {})
-      node = page.search(@xpath)
+    def inject(agent, page, opt = {}, element = page)
+      node = element.search(@xpath)
       text = node.text.to_s
 
       if @truncate


### PR DESCRIPTION
# 概要

`struct_node` 内で `links_node` を使用するとエラーになったので対応してみました。
# エラーの原因

`struct_node` 内の `links_node`  では `Mechanize::Page::Link.new(link, agent, page)` の `page` のクラスが `Mechanize::Page` ではなく `Nokogiri::XML::Element` になるため。

https://github.com/tac0x2a/yasuri/blob/master/lib/yasuri/yasuri_links_node.rb#L14
# 対応方法

`Mechanize::Page` と `Nokogiri::XML::Element` のオブジェクトを両方持ち回り、それぞれ必要に応じて使い分けるようにしました。
`inject` の引数の末尾に `element` を追加し、初期値を `page` にすることで、今まで通りの呼び出し方で動くようにしています。
# その他

`struct_node` 内の `paginate_node` は、次へのリンクを取得するために毎ページ親を遡って必要なだけxpathを適用しなければならず、ちょっと厳しそうだったので今まで通りの動作になっています。
# 例

ページ

```
<!-- http://yasuri.example.net -->
<html>
  <head><title>Yasuri Test</title></head>
  <body>
    <table>
      <tr>
        <td><a href="./child01.html">child01</a></td>
        <td><a href="./child02.html">child02</a></td>
      </tr>
    </table>
    <table>
      <tr>
        <td><a href="./child03.html">child03</a></td>
      </tr>
    </table>
  </body>
</html>
```

※ `child0*.html` はLinks Nodeの例と同じ

コード

```
agent = Mechanize.new
page = agent.get("http://yasuri.example.net")

node = Yasuri.struct_tables '/html/body/table' do
  links_titles './tr/td/a' do
      text_content '/html/body/p'
  end
end

pp node.inject(agent, page)
```

出力

```
[{"titles"=>[{"content"=>"Child 01 page."}, {"content"=>"Child 02 page."}]},
 {"titles"=>[{"content"=>"Child 03 page."}]}]
```
